### PR TITLE
Added shim class to facilitate late binding

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,6 @@
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [clj-python/libpython-clj "1.36"]]
   :repl-options {:init-ns libpython-clj-uberjar-test.core}
-  :main libpython-clj-uberjar-test.core)
+  :aot [libpython-clj-uberjar-test.main]
+  :main libpython-clj-uberjar-test.main
+  )

--- a/src/libpython_clj_uberjar_test/core.clj
+++ b/src/libpython_clj_uberjar_test/core.clj
@@ -1,6 +1,5 @@
 (ns libpython-clj-uberjar-test.core
-  (:require [libpython-clj.require :refer [require-python]])
-  (:gen-class))
+  (:require [libpython-clj.require :refer [require-python]]))
 
 (require-python '[numpy :as numpy])
 

--- a/src/libpython_clj_uberjar_test/main.clj
+++ b/src/libpython_clj_uberjar_test/main.clj
@@ -1,0 +1,21 @@
+(ns libpython-clj-uberjar-test.main
+  (:gen-class :main true))
+
+;;This is the main entry point for the demo.
+;;It's a good example of a shim-class, and
+;;requires some arcane features to get things
+;;working.
+(defn -main [& args]
+  ;;clojure.set isn't imported by default, causing errors when
+  ;;aot-compiling in some places.  May not be necessary here tho,
+  ;;left in just in case.
+  (require 'clojure.set)
+  (binding [*ns* *ns*]
+    ;;rather than :require it in the ns-decl, we load it
+    ;;at runtime.
+    (require 'libpython-clj-uberjar-test.core)
+    (in-ns 'libpython-clj-uberjar-test.core)
+    ;;if we don't use resolve, then we get compile-time aot
+    ;;dependency on marathon.core.  This allows us to shim the
+    ;;class.
+    ((resolve 'libpython-clj-uberjar-test.core/-main))))


### PR DESCRIPTION
lein uberjar now works for me:

```bash
Created /home/tom/repos/libpython-clj-uberjar-test/target/libpython-clj-uberjar-test-0.1.0-SNAPSHOT-standalone.jar
tom@that-place:~/repos/libpython-clj-uberjar-test$ java -jar target/libpython-clj-uberjar-test-0.1.0-SNAPSHOT-standalone.jar 
Feb 25, 2020 6:15:50 PM clojure.tools.logging$eval500$fn__503 invoke
INFO: Executing python initialize with options:{:python-executable nil, :program-name nil, :python-home nil, :library-path nil}
Feb 25, 2020 6:15:50 PM clojure.tools.logging$eval500$fn__503 invoke
INFO: Detecting startup-info for Python executable: 
Feb 25, 2020 6:15:50 PM clojure.tools.logging$eval500$fn__503 invoke
INFO: Startup info detected: {:python-home "/usr", :lib-version "3.5", :libname "python3.5m", :java-library-path-addendum "/usr/lib"}
Feb 25, 2020 6:15:50 PM clojure.tools.logging$eval500$fn__503 invoke
INFO: Reference thread starting
Feb 25, 2020 6:15:50 PM clojure.tools.logging$eval500$fn__503 invoke
INFO: Library python3.5m found at [:system "python3.5m"]
Feb 25, 2020 6:15:51 PM clojure.tools.logging$eval500$fn__503 invoke
INFO: Library c found at [:system "c"]
Hi
[0.         0.04081633 0.08163265 0.12244898 0.16326531 0.20408163
 0.24489796 0.28571429 0.32653061 0.36734694 0.40816327 0.44897959
 0.48979592 0.53061224 0.57142857 0.6122449  0.65306122 0.69387755
 0.73469388 0.7755102  0.81632653 0.85714286 0.89795918 0.93877551
 0.97959184 1.02040816 1.06122449 1.10204082 1.14285714 1.18367347
 1.2244898  1.26530612 1.30612245 1.34693878 1.3877551  1.42857143
 1.46938776 1.51020408 1.55102041 1.59183673 1.63265306 1.67346939
 1.71428571 1.75510204 1.79591837 1.83673469 1.87755102 1.91836735
 1.95918367 2.        ]

```